### PR TITLE
feat: add generate-settings.sh — settings.json generator

### DIFF
--- a/skills/greenfield/scripts/generate-settings.sh
+++ b/skills/greenfield/scripts/generate-settings.sh
@@ -7,6 +7,9 @@ set -e
 #
 # Env vars: PROJECT_DIR, AGENT_TEAMS, PKG_MANAGER
 
+[[ -z "${PROJECT_DIR:-}" ]] && echo "Error: PROJECT_DIR is required" >&2 && exit 1
+[[ -z "${PKG_MANAGER:-}" ]] && echo "Error: PKG_MANAGER is required" >&2 && exit 1
+
 echo "Generating settings files..." >&2
 
 mkdir -p "$PROJECT_DIR/.claude"


### PR DESCRIPTION
## Summary
- Adds `skills/greenfield/scripts/generate-settings.sh` which writes `.claude/settings.json` and `.claude/settings.local.json`
- Configures all 6 hook types (PreToolUse, PostToolUse, Stop, SubagentStop, PreCompact, SessionStart)
- Conditionally includes `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` env var when `AGENT_TEAMS=true`
- Maps 10 package managers (npm, pnpm, yarn, bun, pip, poetry, uv, go, cargo, dotnet) to stack-specific permissions

Closes #7

## Test plan
- [ ] Verify all 10 PKG_MANAGER variants produce valid JSON (`jq .` passes)
- [ ] Verify `AGENT_TEAMS=true` includes env block, `false` omits it
- [ ] Verify settings.json hooks match artifact-specs.md section 2
- [ ] Verify settings.local.json permissions match artifact-specs.md section 3
- [ ] Verify `git add` and `git commit` permissions always included