### PR TITLE
feat: add generate-rules.sh — .claude/rules/ generator

### DIFF
--- a/skills/greenfield/scripts/generate-rules.sh
+++ b/skills/greenfield/scripts/generate-rules.sh
@@ -120,7 +120,7 @@ paths:
 
 - Validate all input — use zod or equivalent
 - Return consistent error shapes with appropriate HTTP status codes
-- Use parameterized queries — never raw string interpolation for SQL
+- Never expose internal error details in production responses
 - Include rate limiting on public-facing endpoints
 RULE
     GENERATED_FILES+=(".claude/rules/api.md")
@@ -130,5 +130,5 @@ esac
 echo "Wrote ${#GENERATED_FILES[@]} rules files" >&2
 
 # Output JSON list of created files
-FILES_JSON=$(printf '"%s",' "${GENERATED_FILES[@]}" | sed 's/,$//')
-echo "{\"status\":\"ok\",\"files\":[$FILES_JSON]}"
+printf -v FILES_JSON '"%s",' "${GENERATED_FILES[@]}"
+printf '{"status":"ok","files":[%s]}\n' "${FILES_JSON%,}"


### PR DESCRIPTION
## Summary
- Adds `skills/greenfield/scripts/generate-rules.sh` which writes `.claude/rules/*.md` files based on detected stack
- Always generates `general.md`, `security.md`, and `testing.md` (with path-scoped frontmatter)
- Conditionally generates `frontend.md` + `api.md` for nextjs/react, or `api.md` for typescript-node
- Follows existing generator script conventions (env var inputs, JSON status output, stderr logging)

Closes #8

## Test plan
- [ ] Run with `STACK=nextjs` — verify 5 files generated (general, security, testing, frontend, api)
- [ ] Run with `STACK=typescript-node` — verify 4 files generated (general, security, testing, api)
- [ ] Run with `STACK=python` — verify 3 files generated (general, security, testing)
- [ ] Verify `testing.md`, `frontend.md`, `api.md` have correct YAML frontmatter path filters
- [ ] Verify JSON output is valid and includes file list
- [ ] Verify missing `PROJECT_DIR` exits with error