### PR TITLE
feat: add generate-hooks.sh — .claude/hooks/ generator

### DIFF
--- a/skills/greenfield/scripts/generate-hooks.sh
+++ b/skills/greenfield/scripts/generate-hooks.sh
@@ -27,7 +27,7 @@ mkdir -p "$HOOKS_DIR"
 case "$FORMATTER" in
   prettier)      FMT_CMD='npx prettier --write "$FILE" 2>/dev/null || true' ;;
   biome)         FMT_CMD='npx @biomejs/biome format --write "$FILE" 2>/dev/null || true' ;;
-  ruff)          FMT_CMD='ruff format "$FILE" 2>/dev/null || black "$FILE" 2>/dev/null || true' ;;
+  ruff)          FMT_CMD='ruff format "$FILE" 2>/dev/null || true' ;;
   gofmt)         FMT_CMD='gofmt -w "$FILE" 2>/dev/null || true' ;;
   rustfmt)       FMT_CMD='rustfmt "$FILE" 2>/dev/null || true' ;;
   dotnet-format) FMT_CMD='dotnet format --include "$FILE" 2>/dev/null || true' ;;
@@ -85,7 +85,7 @@ AGENT_TYPE=$(echo "$INPUT" | jq -r '.agent_type // "main"')
 [[ "$AGENT_TYPE" == "hook-agent" ]] && exit 0
 ERRORS=""
 cd "$CLAUDE_PROJECT_DIR"
-UNCOMMITTED=$(git diff --name-only HEAD 2>/dev/null || echo "")
+UNCOMMITTED=$(git diff --name-only HEAD 2>/dev/null || git ls-files 2>/dev/null || echo "")
 MERGE_BASE=$(git merge-base HEAD main 2>/dev/null || git merge-base HEAD master 2>/dev/null || echo "")
 if [[ -n "$MERGE_BASE" ]]; then
   COMMITTED=$(git diff --name-only "$MERGE_BASE"...HEAD 2>/dev/null || echo "")


### PR DESCRIPTION
## Summary
- Adds `generate-hooks.sh` that generates 6 Claude Code hook scripts into `.claude/hooks/`
- Supports 6 formatters (prettier, biome, ruff, gofmt, rustfmt, dotnet-format) via `FORMATTER` env var
- Bakes `LINT_CMD` and `TEST_CMD` into the quality gate hook at generation time using safe shell escaping

## Hook Scripts Generated
| Hook | Event | Purpose |
|---|---|---|
| guard.sh | PreToolUse | Block destructive commands and secret exposure |
| format.sh | PostToolUse | Auto-format edited files with detected formatter |
| stop-quality-gate.sh | Stop/SubagentStop | Run lint + test before task completion |
| task-summary.sh | Stop | Log session summary to `.claude/logs/` |
| save-context.sh | PreCompact | Save WIP snapshot before context compaction |
| session-start.sh | SessionStart | Display git state at session start |

Closes #9

## Test plan
- [ ] Run with `FORMATTER=prettier` and verify format.sh contains prettier command
- [ ] Run with `FORMATTER=ruff` and verify format.sh contains ruff command
- [ ] Verify all 6 scripts are generated and executable
- [ ] Verify stop-quality-gate.sh has LINT_CMD/TEST_CMD baked in as literals
- [ ] Run twice to confirm idempotency