### PR TITLE
feat: add generate-claude-md.sh — CLAUDE.md generator

### DIFF
--- a/skills/greenfield/scripts/generate-claude-md.sh
+++ b/skills/greenfield/scripts/generate-claude-md.sh
@@ -25,6 +25,8 @@ GENERATED_FILES=()
 
 echo "Generating CLAUDE.md..." >&2
 
+mkdir -p "$PROJECT_DIR"
+
 cat > "$PROJECT_DIR/CLAUDE.md" <<CLAUDEMD
 # ${PROJECT_NAME}
 


### PR DESCRIPTION
## Summary
- Adds `generate-claude-md.sh` that writes `CLAUDE.md` at the project root using interview answers
- Accepts 10 env vars: `PROJECT_DIR`, `PROJECT_NAME`, `PROJECT_DESCRIPTION`, `STACK`, `INSTALL_CMD`, `DEV_CMD`, `BUILD_CMD`, `TEST_CMD`, `LINT_CMD`, `COMMIT_STYLE`
- Validates required vars (`PROJECT_DIR`, `PROJECT_NAME`), provides sensible defaults for the rest
- Follows project conventions: `set -e`, stderr logging, JSON status output, `GENERATED_FILES` array

Closes #10

## Test plan
- [ ] Run with minimal env vars (`PROJECT_DIR`, `PROJECT_NAME`) and verify defaults
- [ ] Run with all 10 env vars and verify substitution
- [ ] Verify missing `PROJECT_DIR` exits with error
- [ ] Verify missing `PROJECT_NAME` exits with error
- [ ] Verify output matches artifact-specs.md template