### PR TITLE
feat: add generate-gitignore.sh — .gitignore updater

### DIFF
--- a/skills/greenfield/scripts/generate-gitignore.sh
+++ b/skills/greenfield/scripts/generate-gitignore.sh
@@ -23,12 +23,13 @@ ENTRIES=(
 )
 
 # Create .gitignore if it doesn't exist
+mkdir -p "$PROJECT_DIR"
 touch "$GITIGNORE"
 
 # Collect entries that aren't already present
 MISSING=()
 for ENTRY in "${ENTRIES[@]}"; do
-  if ! grep -qF "$ENTRY" "$GITIGNORE" 2>/dev/null; then
+  if ! grep -qxF "$ENTRY" "$GITIGNORE" 2>/dev/null; then
     MISSING+=("$ENTRY")
   fi
 done


### PR DESCRIPTION
## Summary
- Adds `skills/greenfield/scripts/generate-gitignore.sh` (Step 7 of greenfield pipeline)
- Idempotently appends Claude Code entries (`CLAUDE.local.md`, `.claude/settings.local.json`, `.claude/logs/`, `.claude/scratch/`, `.claude/tasks/`, `.claude/specs/`) with a `# Claude Code` section header
- Creates `.gitignore` if missing; skips entries already present
- Fixed ordering bug from spec where header would appear after entries

## Test plan
- [ ] Run on empty directory — creates `.gitignore` with header + 6 entries, outputs `{"status":"ok","entries_added":6}`
- [ ] Run again — adds 0 entries (idempotent), outputs `{"status":"ok","entries_added":0}`
- [ ] Run on `.gitignore` with some entries pre-existing — only adds missing ones

Closes #11